### PR TITLE
STEP 12: 선정한 동시성 제어방식 구현 및 관련 테스트

### DIFF
--- a/src/main/java/io/hhplus/conbook/aop/DistributedLock.java
+++ b/src/main/java/io/hhplus/conbook/aop/DistributedLock.java
@@ -1,0 +1,11 @@
+package io.hhplus.conbook.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+}

--- a/src/main/java/io/hhplus/conbook/aop/DistributedLockAop.java
+++ b/src/main/java/io/hhplus/conbook/aop/DistributedLockAop.java
@@ -1,0 +1,55 @@
+package io.hhplus.conbook.aop;
+
+import io.hhplus.conbook.infra.redis.RedisLockRepository;
+import io.hhplus.conbook.interfaces.api.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+@Slf4j
+@Aspect
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class DistributedLockAop {
+    private final RedisLockRepository redisLockRepository;
+
+    @Around("@annotation(distributedLock)")
+    public Object executeLock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        Long seatId = extractSeatId(joinPoint);
+        String key = String.format("lock:seatId:%d", seatId);
+
+        log.debug("Start to request distribution lock for {}", key);
+        try {
+            if (!redisLockRepository.lock(key)) {
+                throw new IllegalStateException(ErrorCode.LOCK_ACQUISITION_FAILED.getCode());
+            }
+            return joinPoint.proceed();
+        } finally {
+            redisLockRepository.unlock(key);
+            log.debug("Return distribution lock for {}", key);
+        }
+    }
+
+    private Long extractSeatId(ProceedingJoinPoint joinPoint) {
+        Object[] givenArgs = joinPoint.getArgs();
+
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        Parameter[] parameters = method.getParameters();
+
+        for (int i=0; i< parameters.length; i++) {
+            if (parameters[i].isAnnotationPresent(SimpleLockKey.class)) {
+                return (Long) givenArgs[i];
+            }
+        }
+        throw new IllegalStateException();
+    }
+}

--- a/src/main/java/io/hhplus/conbook/aop/SimpleLockKey.java
+++ b/src/main/java/io/hhplus/conbook/aop/SimpleLockKey.java
@@ -1,0 +1,11 @@
+package io.hhplus.conbook.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SimpleLockKey {
+}

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -11,7 +11,6 @@ import io.hhplus.conbook.domain.user.User;
 import io.hhplus.conbook.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -31,7 +30,6 @@ public class ConcertBookingFacade {
      * - 좌석을 미리 안 만들 경우 어떤 식으로 처리할 지는 추후 여유가 있을 때 구현
      *  (좌석의 좌표값(x,y)만 제공될 경우)
      */
-    @Transactional
     public ConcertBookingResult.BookingSeat bookConcertSeat(ConcertBookingCommand.BookingSeat booking) {
         User user = userService.getUserByUUID(booking.userUUID());
         ConcertSchedule concertSchedule = concertService.getConcertSchedule(booking.concertId(), booking.date());

--- a/src/main/java/io/hhplus/conbook/domain/booking/BookingService.java
+++ b/src/main/java/io/hhplus/conbook/domain/booking/BookingService.java
@@ -1,5 +1,7 @@
 package io.hhplus.conbook.domain.booking;
 
+import io.hhplus.conbook.aop.DistributedLock;
+import io.hhplus.conbook.aop.SimpleLockKey;
 import io.hhplus.conbook.domain.concert.ConcertSchedule;
 import io.hhplus.conbook.domain.concert.Seat;
 import io.hhplus.conbook.domain.concert.SeatRepository;
@@ -25,9 +27,10 @@ public class BookingService {
      * @param user
      * @return
      */
+    @DistributedLock
     @Transactional
-    public Booking createBooking(ConcertSchedule schedule, long seatId, User user) {
-        Seat seat = seatRepository.findSeatWithPessimisticLock(seatId, schedule.getId());
+    public Booking createBooking(ConcertSchedule schedule, @SimpleLockKey long seatId, User user) {
+        Seat seat = seatRepository.findSeatBy(seatId, schedule.getId());
         if (seat.isOccupied()) throw new AlreadyOccupiedException(ErrorCode.NOT_AVAILABLE_SEAT.getCode());
 
         seat.addSchedule(schedule);

--- a/src/main/java/io/hhplus/conbook/interfaces/api/ErrorCode.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/api/ErrorCode.java
@@ -40,8 +40,11 @@ public enum ErrorCode {
     WAITING_TOKEN_VALIDATION_FAILED("5005", "WAITING 토큰 검증에 실패하였습니다."),
 
     // --- 필터 Error ---
-    
+
     UNAUTHORIZED_ACCESS("6001", "허가되지 않은 접근입니다."),
+
+    // --- 필터 Error ---
+    LOCK_ACQUISITION_FAILED("7001", "분산 락(Distributed Lock) 획득에 실패하였습니다."),
 
     // --- Server Error ---
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,7 @@ springdoc:
   api-docs:
     enabled: true
 
+#logging:
+#  level:
+#    org.springframework.orm: debug
+#    io.hhplus.conbook: debug

--- a/src/test/java/io/hhplus/conbook/domain/booking/BookingServiceTest.java
+++ b/src/test/java/io/hhplus/conbook/domain/booking/BookingServiceTest.java
@@ -13,6 +13,8 @@ import io.hhplus.conbook.infra.db.concert.SeatJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -30,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 class BookingServiceTest {
+
+    private static final Logger log = LoggerFactory.getLogger(BookingServiceTest.class);
+
     // test target
     @Autowired
     BookingService bookingService;
@@ -154,8 +159,8 @@ class BookingServiceTest {
             tasks.add(() -> {
                 try {
                     bookingService.createBooking(schedule, seat.getId(), user);
-                } catch (AlreadyOccupiedException e) {
-                    System.out.printf("[FAIL] 예약 실패 - 사용자 id: %d, 좌석 id: %d\n", user.getId(), seat.getId());
+                } catch (AlreadyOccupiedException | IllegalStateException e) {
+                    log.error("[FAIL] 예약 실패 - 사용자 id: {}, 좌석 id: {}", user.getId(), seat.getId());
                 }
             });
         }

--- a/src/test/java/io/hhplus/conbook/domain/point/PointServiceTest.java
+++ b/src/test/java/io/hhplus/conbook/domain/point/PointServiceTest.java
@@ -1,9 +1,16 @@
 package io.hhplus.conbook.domain.point;
 
+import io.hhplus.conbook.infra.db.point.UserPointEntity;
+import io.hhplus.conbook.infra.db.point.UserPointJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -17,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class PointServiceTest {
 
+    private static final Logger log = LoggerFactory.getLogger(PointServiceTest.class);
+
     // test target
     @Autowired
     PointService pointService;
@@ -24,8 +33,65 @@ class PointServiceTest {
     // helpers
     @Autowired
     UserPointRepository userPointRepository;
+    @Autowired
+    UserPointJpaRepository userPointJpaRepository;
+
+    @BeforeEach
+    @Transactional
+    void setup() {
+        List<UserPointEntity> points = userPointJpaRepository.findAll();
+
+        for (UserPointEntity point : points) {
+            ReflectionTestUtils.setField(point, "point", 10000L);
+        }
+    }
 
     // =============================================================================================
+
+    @Test
+    @DisplayName("[동시성]: 사용자 포인트의 사용과 충전이 동시에 요청된 시나리오")
+    void concurrencyOfPaymentAndCharge() {
+        // given
+        long userId = 1L;
+        long payment = 1600;
+        long charge = 800;
+
+        LocalDateTime payTime = LocalDateTime.now().plusSeconds(1).truncatedTo(ChronoUnit.MICROS);
+        LocalDateTime chargeTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
+
+        long startPoint = userPointRepository.getUserPoint(userId).getPoint();
+
+        // when
+        List<Runnable> tasks = new ArrayList<>();
+        tasks.add(() -> {
+            try {
+                pointService.spendPoint(userId, payment, payTime);
+
+            } catch (NotValidRequestException e) {
+                log.error("[FAIL] charge - reqTime: ", payTime);
+            }
+        });
+
+        tasks.add(() -> {
+            try {
+                pointService.chargePoint(userId, charge, chargeTime);
+
+            } catch (NotValidRequestException e) {
+                log.error("[FAIL] charge - reqTime: ", chargeTime);
+            }
+        });
+
+        CompletableFuture allTask =
+                CompletableFuture.allOf(
+                        tasks.stream().map(task -> runAsync(task)).toArray(CompletableFuture[]::new)
+                );
+        allTask.join();
+
+        // then
+        long endPoint = userPointRepository.getUserPoint(userId).getPoint();
+
+        assertThat(800).isEqualTo(startPoint - endPoint);
+    }
 
     @Test
     @DisplayName("[동시성]: 충전 - 예상치 못한 이유로 중복으로 요청하는 시나리오")
@@ -44,7 +110,7 @@ class PointServiceTest {
                     pointService.chargePoint(userId, amount, reqTime);
 
                 } catch (NotValidRequestException e) {
-                    System.out.printf("[FAIL] charge - reqTime: %s\n", reqTime);
+                    log.error("[FAIL] charge - reqTime: ", reqTime);
                 }
             });
         }
@@ -77,7 +143,7 @@ class PointServiceTest {
                     pointService.spendPoint(userId, amount, reqTime);
 
                 } catch (NotValidRequestException e) {
-                    System.out.printf("[FAIL] charge - reqTime: %s\n", reqTime);
+                    log.error("[FAIL] charge - reqTime: ", reqTime);
                 }
             });
         }


### PR DESCRIPTION
### 변경 내역
- Custom Annotation과 AOP 를 활용한 redis 기본락 구현 적용
- 예약 기능 수정 상황에 맞춰 동시성 테스트를 통과하도록 테스트 코드 수정
- 유저 포인트 관련 동시성 테스트 케이스 추가

### 리뷰 포인트
- 유저 포인트의 경우 높은 데이터 정합성이 필요하기 때문에 비관적락을 사용하고자 합니다. 기존에 이미 비관적 락을 사용하여 포인트 사용 및 충전을 구현했기 때문에 사용과 충전이 동시에 발생하는 테스트 케이스만 추가하였습니다.
- 좌석예약은 reds 기본 락을 사용해서 동시성 제어를 했습니다. 커스텀 어노테이션과 AOP를 활용해서 트랜잭션이 시작하기 전 Lock을 얻고 트랜잭션이 끝나고난뒤 Lock을 반환하도록 처리했습니다. [참고: 4faf40cd881e2677ed1c82b53132b9b156cd476d]
- 좌석예약시 기본락을 얻고 내부 트랜잭션에서는 별도로 Lock을 얻지 않도록 로직을 수정했는데 괜찮을까요???
- 좌석예약에 대한 기존 동시성 테스트를 redis 락을 가지고 통과할 수 있도록 테스트 코드 리팩토링 했습니다.