### PR TITLE
STEP 16: 서비스 분리 시 발생하는 문제점과 해결 전략 및 Application Event를 활용한 부가기능 추가

### DIFF
--- a/docs/README_SERVICE_TRANSACTION_BOUNDARIES.md
+++ b/docs/README_SERVICE_TRANSACTION_BOUNDARIES.md
@@ -1,0 +1,143 @@
+# 서비스 트랜잭션 범위 분석 및 확장 전략
+
+서비스가 제공하는 기능은 UseCase별로 트랜잭션 범위가 다 다르다.
+
+기능별로 다른 트랜잭션 범위는 서비스가 확장될 때 예상하지 못한 문제를 발생시킬 수 있다.
+따라서 해당 보고서는 UseCase에 따른 트랜잭션 범위를 이해하고 서비스가 확장 전략 수립을 목표로한다.
+
+<br>
+
+## 기능별 트랜잭션 범위
+
+### 예약가능한 공연 일정 조회 case - ConcertFacade
+
+- 단일 도메인 서비스를 사용해서 콘서트 일정을 제공한다.
+
+### 예약가능한 좌석 조회 case - ConcertFacade
+
+- 단일 도메인 서비스를 사용해서 콘서트 일정을 확인하고 좌석정보를 제공한다.
+
+### 콘서트 예약 case - ConcertBookingFacade
+
+- 두 개 이상의 도메인 서비스를 복합적으로 사용한다.
+- UseCase의 트랜잭션 범위는 여러 서비스 작업들이 모여 구성된 하나의 논리적 작업 단위이다.
+- UseCase 처리를 위한 작업 순서는 다음과 같다.
+  1. 사용자 도메인 서비스를 사용해서 사용자 정보를 조회한다.
+  2. 콘서트 도메인 서비스를 사용해서 요청한 콘서트 일정을 조회한다.
+  3. 예약 도메인 서비스를 사용해서 좌석을 조회하고 예약 처리를 한다. (DistributedLock - simple)
+  4. 예약 도메인의 스케쥴러를 사용해서 정해진 시간동안 결제가 안이루어지면 취소처리하도록 한다.
+  5. 콘서트 도메인 서비스를 사용해서 해당 공연일자의 예약 가능 좌석 수를 수정한다.
+
+### 포인트 충전 / 조회 case - PointFacade
+
+- 단일 도메인 서비스를 사용해서 포인트를 충전하거나 포인트를 조회한다.
+
+### 결제 case - BookingPaymentFacade
+
+- 두 개 이상의 도메인 서비스를 복합적으로 사용한다.
+- UseCase의 트랜잭션 범위는 여러 서비스 작업들이 모여 구성된 하나의 논리적 작업 단위이다. 
+- UseCase 처리를 위한 작업 순서는 다음과 같다.
+  1. 예약 도메인 서비스를 사용해서 예약 건을 결제상태로 변경한다.
+  2. 사용자 도메인 서비스를 사용해서 결제를 한 사용자를 조회한다.
+  3. 포인트 도메인 서비스를 사용해서 해당하는 사용자의 포인트를 차감한다.
+  4. 포인트 도메인 서비스를 사용해서 포인트 차감 이력을 저장한다.
+  5. 토큰 도메인 서비스를 사용해서 액세스 토큰의 권한을 만료시킨다.
+
+<br>
+
+## 서비스 분리 전략
+
+트랜잭션 범위는 서비스가 제공하는 기능(UseCase)에 대한 논리적 범위와 동일하다.
+
+논리적 범위라는 관점에서 트랜잭션은 다음의 특성을 갖는다.
+- 도메인 영역과 밀접한 관련이 있다.
+- 도메인 간의 협력으로 구성되더라도 각 도메인 영역은 독립적일 수 있다.
+
+단일 도메인 영역과 연결되는 트랜잭션과 복합적인 도메인 영역과 연결되는 트랜잭션 처리의 복잡도는 다르다.
+
+서비스 규모가 작을 때는 트랜잭션 범위가 길고 처리 복잡도가 높더라도 문제가 되지 않으나, 서비스 사용자 규모가 달라지고
+트래픽 및 사용 데이터가 증가하면 서버에 부하를 발생시켜 예상하지 못한 이슈가 발생할 수 있다.
+
+현재 구조에서 발생할 수 있는 문제를 방지하기 위해 서비스 규모가 확장되어 서비스를 분리한다고 가정한다.
+
+<br>
+
+### 도메인 별 분리
+
+기능별 트랜잭션 범위를 분석할 때 확인한 것처럼 서비스는 도메인의 협력으로 구성되어있다. 따라서 하나의 거대 서비스를
+각각의 도메인 서비스 간의 협력으로 분리할 수 있다.
+
+도메인들이 독립적인 서비스로 분리될 경우 스프링에서 제공하는 트랜잭션 관리 기능을 쓸 수 없다는 단점이 존재한다.
+
+```java
+@Transactional
+public ConcertBookingResult.BookingSeat bookConcertSeat(ConcertBookingCommand.BookingSeat booking) {
+    User user = userService.getUserByUUID(booking.userUUID());
+    ConcertSchedule concertSchedule = concertService.getConcertSchedule(booking.concertId(), booking.date());
+
+    Booking bookingResult = bookingService.createBooking(concertSchedule, booking.seatId(), user);
+    bookingScheduler.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
+    concertService.updateScheduleStatus(booking.concertId(), booking.date());
+    ...
+}
+```
+
+단일 서비스는 위처럼 @Transactional 어노테이션만 추가하면 별도의 작업없이 예외처리를 할 수 있다. 하지만 도메인별로 
+서비스를 분리하면 이는 불가능하다.
+
+<br>
+
+### 보상 트랜잭션 - Application Event
+
+도메인 서비스간의 협력으로 서비스를 구성하는 것처럼 협력을 통해 트랜잭션 문제를 해결한다.
+
+도메인을 기준으로 분리된 이후 UseCase를 제공할 때 각 서비스를 각각 작업 후 트랜잭션을 커밋한다. 선행작업의 커밋 이후
+후행 작업에서 실패가 발생하면 이전에 완료된 작업을 취소시켜 논리적 트랜잭션의 원자성을 준수하는데 이를
+'보상 트랜잭션'이라 한다.
+
+도메인 서비스에서 작업을 실패하면 롤백처리해야하는 작업을 요청하는 Event를 발행하고 다른 도메인 서비스에게 작업을 요청한다.
+
+'좌석 예약'과 '결제'의 UseCase로 살펴보면 다음과 같다. (편의상 조회 작업제외) 
+
+```text
+- 좌석예약
+1. 예약도메인 서비스
+   좌석 예약 처리 완료 - DB commit
+   예약관련 스케쥴러 등록 - memory
+
+2. 콘서트 도메인 서비스
+   콘서트 일정의 예약가능한 좌석 수 수정 - UnExpected Exception
+   ConcertScheduleAvailableSeatFailEvent 발생 및 발행
+   ConcertScheduleAvailableSeatFailEventListener로 예약 서비스에 예약처리 롤백 및 스케쥴러 제거 요청
+```
+
+---
+
+```text
+- 결제
+i) 포인트 차감에 실패할 경우
+1. 예약 도메인 서비스
+   예약 상태를 결제 상태로 변경 - DB commit
+
+2. 포인트 도메인 서비스
+   사용자 포인트 차감 - UnExpected Exception
+   UserPointUpdateFailEvent 발생 및 발행
+   UserPointUpdateFailEventListener로 예약 도메인 서비스에 상태변경 작업의 롤백 요청
+
+ii) 액세스 토큰 권한 만료에 실패할 경우
+1. 예약 도메인 서비스
+   예약 상태를 결제 상태로 변경 - DB commit
+
+2. 포인트 도메인 서비스
+   사용자 포인트 차감 - DB commit
+   
+3. 토큰 도메인 서비스
+   액세스 토큰 권한 만료 - UnExpected Exception
+   ExpireTokenFailEvent 발생 및 발행
+   ExpireTokenFailEventListener로 포인트 서비스와 예약 서비스에게 작업의 롤백을 요청한다.
+
+* 포인트 차감 이력을 저장하는 기능은 관심사 분리를 통해 메인 비즈니스 로직과 분리시킨다.
+```
+
+<br>
+

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -91,6 +91,17 @@ create table token
     primary key (id)
 );
 
+create table notification_log
+(
+    id            bigint    not null auto_increment,
+    booking_id    bigint,
+    finished_at    datetime(6),
+    primary key (id)
+) engine=InnoDB;
+
+alter table if exists notification_log
+    add constraint UKnotificationid unique (id);
+
 alter table if exists payment
     add constraint UKku02qy6369hn9uhy3n7jk9v6e unique (booking_id);
 

--- a/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
@@ -1,0 +1,38 @@
+package io.hhplus.conbook.application.client;
+
+import io.hhplus.conbook.domain.client.BookingHistory;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class ClientCommand {
+    @Builder
+    public record Notify(
+            Long bookingId,
+            Long concertId,
+            String title,
+            LocalDate concertDate,
+            Long seatId,
+            String seatRow,
+            int seatNo,
+            Long userId,
+            String userName,
+            LocalDateTime bookingDateTime
+    ) {
+        public BookingHistory toBookingHistory() {
+            return BookingHistory.builder()
+                    .bookingId(bookingId)
+                    .concertId(concertId)
+                    .title(title)
+                    .concertDate(concertDate)
+                    .seatId(seatId)
+                    .seatRow(seatRow)
+                    .seatNo(seatNo)
+                    .userId(userId)
+                    .userName(userName)
+                    .bookingDateTime(bookingDateTime)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/io/hhplus/conbook/application/client/ClientFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientFacade.java
@@ -1,0 +1,15 @@
+package io.hhplus.conbook.application.client;
+
+import io.hhplus.conbook.domain.client.ClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClientFacade {
+    private final ClientService clientService;
+
+    public void notifyBookingHistory(ClientCommand.Notify command) {
+        clientService.notifyBookingHistory(command.toBookingHistory());
+    }
+}

--- a/src/main/java/io/hhplus/conbook/application/client/ClientLogCommand.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientLogCommand.java
@@ -1,0 +1,10 @@
+package io.hhplus.conbook.application.client;
+
+import java.time.LocalDateTime;
+
+public class ClientLogCommand {
+    public record Save (
+            long bookingId,
+            LocalDateTime finishedAt
+    ) {}
+}

--- a/src/main/java/io/hhplus/conbook/application/client/ClientLogFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientLogFacade.java
@@ -1,0 +1,16 @@
+package io.hhplus.conbook.application.client;
+
+import io.hhplus.conbook.domain.client.ClientLogService;
+import io.hhplus.conbook.domain.client.NotifactionLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClientLogFacade {
+    private final ClientLogService clientLogService;
+
+    public void saveNotificationHistory(ClientLogCommand.Save command) {
+        clientLogService.saveHistory(new NotifactionLog(command.bookingId(), command.finishedAt()));
+    }
+}

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -2,6 +2,7 @@ package io.hhplus.conbook.application.concert;
 
 import io.hhplus.conbook.application.concert.dto.ConcertBookingCommand;
 import io.hhplus.conbook.application.concert.dto.ConcertBookingResult;
+import io.hhplus.conbook.application.event.ConcertBookingEventPublisher;
 import io.hhplus.conbook.domain.booking.Booking;
 import io.hhplus.conbook.domain.booking.BookingService;
 import io.hhplus.conbook.domain.concert.ConcertSchedule;
@@ -26,6 +27,7 @@ public class ConcertBookingFacade {
     private final ConcertService concertService;
     private final BookingService bookingService;
     private final BookingScheduler bookingScheduler;
+    private final ConcertBookingEventPublisher concertBookingEventPublisher;
 
     /**
      * 각 공연은 모두 좌석을 생성한다고 가정.
@@ -41,6 +43,8 @@ public class ConcertBookingFacade {
         Booking bookingResult = bookingService.createBooking(concertSchedule, booking.seatId(), user);
         bookingScheduler.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
         concertService.updateSeatStatus(booking.concertId(), booking.date());
+
+        concertBookingEventPublisher.publishEventOn(bookingResult);
 
         return ConcertBookingResult.BookingSeat.builder()
                 .bookingId(bookingResult.getId())

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -2,16 +2,17 @@ package io.hhplus.conbook.application.concert;
 
 import io.hhplus.conbook.application.concert.dto.ConcertBookingCommand;
 import io.hhplus.conbook.application.concert.dto.ConcertBookingResult;
-import io.hhplus.conbook.config.ScheduledTaskExecutor;
 import io.hhplus.conbook.domain.booking.Booking;
 import io.hhplus.conbook.domain.booking.BookingService;
 import io.hhplus.conbook.domain.concert.ConcertSchedule;
 import io.hhplus.conbook.domain.concert.ConcertService;
 import io.hhplus.conbook.domain.user.User;
 import io.hhplus.conbook.domain.user.UserService;
+import io.hhplus.conbook.interfaces.schedule.booking.BookingScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class ConcertBookingFacade {
     private final UserService userService;
     private final ConcertService concertService;
     private final BookingService bookingService;
-    private final ScheduledTaskExecutor scheduledTaskExecutor;
+    private final BookingScheduler bookingScheduler;
 
     /**
      * 각 공연은 모두 좌석을 생성한다고 가정.
@@ -32,12 +33,13 @@ public class ConcertBookingFacade {
      *  (좌석의 좌표값(x,y)만 제공될 경우)
      */
     @CacheEvict(value = "concertSchedules", key = "#serach.concertId")
+    @Transactional
     public ConcertBookingResult.BookingSeat bookConcertSeat(ConcertBookingCommand.BookingSeat booking) {
         User user = userService.getUserByUUID(booking.userUUID());
         ConcertSchedule concertSchedule = concertService.getConcertSchedule(booking.concertId(), booking.date());
 
         Booking bookingResult = bookingService.createBooking(concertSchedule, booking.seatId(), user);
-        scheduledTaskExecutor.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
+        bookingScheduler.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
         concertService.updateSeatStatus(booking.concertId(), booking.date());
 
         return ConcertBookingResult.BookingSeat.builder()

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -42,7 +42,7 @@ public class ConcertBookingFacade {
 
         Booking bookingResult = bookingService.createBooking(concertSchedule, booking.seatId(), user);
         bookingScheduler.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
-        concertService.updateSeatStatus(booking.concertId(), booking.date());
+        concertService.updateScheduleStatus(booking.concertId(), booking.date());
 
         concertBookingEventPublisher.publishEventOn(bookingResult);
 

--- a/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
+++ b/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
@@ -1,0 +1,22 @@
+package io.hhplus.conbook.application.event;
+
+import io.hhplus.conbook.domain.booking.Booking;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ConcertBookingEvent {
+
+//    private Long bookingId;
+//    private Long concertId;
+//    private String title;
+//    private LocalDate concertDate;
+//    private Long seatId;
+//    private String seatRow;
+//    private int seatNo;
+//    private Long userId;
+//    private String userName;
+//    private LocalDateTime bookingDateTime;
+    private Booking booking;
+}

--- a/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisher.java
+++ b/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisher.java
@@ -1,0 +1,20 @@
+package io.hhplus.conbook.application.event;
+
+import io.hhplus.conbook.domain.booking.Booking;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertBookingEventPublisher {
+    private final ApplicationEventPublisher publisher;
+
+    public void publishEventOn(Booking bookingResult) {
+        log.info("EVENT - ConcertBookingEvent");
+
+        publisher.publishEvent(new ConcertBookingEvent(bookingResult));
+    }
+}

--- a/src/main/java/io/hhplus/conbook/config/AsyncConfig.java
+++ b/src/main/java/io/hhplus/conbook/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package io.hhplus.conbook.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(5);    // 기본 스레드 풀 크기
+        taskExecutor.setMaxPoolSize(20);    // 최대 스레드 풀 크기
+        taskExecutor.setQueueCapacity(50);  // 대기 큐 크기
+        taskExecutor.setThreadNamePrefix("ASYNC-");
+        taskExecutor.initialize();
+
+        return taskExecutor;
+    }
+}

--- a/src/main/java/io/hhplus/conbook/domain/client/BookingHistory.java
+++ b/src/main/java/io/hhplus/conbook/domain/client/BookingHistory.java
@@ -1,0 +1,20 @@
+package io.hhplus.conbook.domain.client;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+public record BookingHistory(
+        Long bookingId,
+        Long concertId,
+        String title,
+        LocalDate concertDate,
+        Long seatId,
+        String seatRow,
+        int seatNo,
+        Long userId,
+        String userName,
+        LocalDateTime bookingDateTime) {
+}

--- a/src/main/java/io/hhplus/conbook/domain/client/ClientLogService.java
+++ b/src/main/java/io/hhplus/conbook/domain/client/ClientLogService.java
@@ -1,0 +1,17 @@
+package io.hhplus.conbook.domain.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClientLogService {
+    private final NotificationLogRepository notificationLogRepository;
+
+    @Transactional
+    public void saveHistory(NotifactionLog notifactionLog) {
+        notificationLogRepository.save(notifactionLog);
+    }
+}

--- a/src/main/java/io/hhplus/conbook/domain/client/ClientService.java
+++ b/src/main/java/io/hhplus/conbook/domain/client/ClientService.java
@@ -1,0 +1,6 @@
+package io.hhplus.conbook.domain.client;
+
+public interface ClientService {
+
+    void notifyBookingHistory(BookingHistory bookingHistory);
+}

--- a/src/main/java/io/hhplus/conbook/domain/client/NotifactionLog.java
+++ b/src/main/java/io/hhplus/conbook/domain/client/NotifactionLog.java
@@ -1,0 +1,13 @@
+package io.hhplus.conbook.domain.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class NotifactionLog {
+    private Long bookingId;
+    private LocalDateTime finishedAt;
+}

--- a/src/main/java/io/hhplus/conbook/domain/client/NotificationLogRepository.java
+++ b/src/main/java/io/hhplus/conbook/domain/client/NotificationLogRepository.java
@@ -1,0 +1,6 @@
+package io.hhplus.conbook.domain.client;
+
+public interface NotificationLogRepository {
+    NotifactionLog save(NotifactionLog log);
+    NotifactionLog findByBookingId(Long bookingId);
+}

--- a/src/main/java/io/hhplus/conbook/domain/concert/ConcertService.java
+++ b/src/main/java/io/hhplus/conbook/domain/concert/ConcertService.java
@@ -47,12 +47,11 @@ public class ConcertService {
     }
 
     private LocalDate convertToLocalDate(String date) {
-        LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
-        return localDate;
+        return LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyyMMdd"));
     }
 
     @Transactional
-    public void updateSeatStatus(long concertId, String date) {
+    public void updateScheduleStatus(long concertId, String date) {
         LocalDate localDate = convertToLocalDate(date);
         ConcertSchedule schedule = scheduleRepository.findScheduleBy(concertId, localDate);
         schedule.audienceIncrease();

--- a/src/main/java/io/hhplus/conbook/infra/client/FileSysClientService.java
+++ b/src/main/java/io/hhplus/conbook/infra/client/FileSysClientService.java
@@ -1,0 +1,58 @@
+package io.hhplus.conbook.infra.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.hhplus.conbook.domain.client.BookingHistory;
+import io.hhplus.conbook.domain.client.ClientService;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+public class FileSysClientService implements ClientService {
+    protected static final String CONTEXT_PATH = "./history";
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostConstruct
+    void init() {
+        objectMapper.registerModule(new JavaTimeModule())
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    }
+
+    @Override
+    public void notifyBookingHistory(BookingHistory bookingHistory) {
+        try {
+            File historyFile = getHistoryFileOrDefault();
+            String historyJson = objectMapper.writeValueAsString(bookingHistory) + "\n";
+            Files.write(historyFile.toPath(), historyJson.getBytes(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+
+        } catch (IOException e) {
+            log.error(e.toString());
+        }
+    }
+
+    private File getHistoryFileOrDefault() throws IOException {
+        String month = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        String today = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        log.debug("month: {}, today: {}", month, today);
+
+        File historyDir = new File(CONTEXT_PATH + File.separator + month);
+        if (!historyDir.exists()) historyDir.mkdirs();
+
+        File historyFile = new File(historyDir.getPath() + File.separator + today);
+        if (!historyFile.exists()) historyFile.createNewFile();
+
+        return historyFile;
+    }
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogEntity.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogEntity.java
@@ -1,0 +1,29 @@
+package io.hhplus.conbook.infra.db.client;
+
+import io.hhplus.conbook.domain.client.NotifactionLog;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "notification_log")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class NotificationLogEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long bookingId;
+    private LocalDateTime finishedAt;
+
+    public NotificationLogEntity(NotifactionLog log) {
+        this.bookingId = log.getBookingId();
+        this.finishedAt = log.getFinishedAt();
+    }
+
+    public NotifactionLog toDomain() {
+        return new NotifactionLog(bookingId, finishedAt);
+    }
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogJpaRepository.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogJpaRepository.java
@@ -1,0 +1,9 @@
+package io.hhplus.conbook.infra.db.client;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationLogJpaRepository extends JpaRepository<NotificationLogEntity, Long> {
+    Optional<NotificationLogEntity> findByBookingId(Long bookingId);
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogRepositoryImpl.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/client/NotificationLogRepositoryImpl.java
@@ -1,0 +1,26 @@
+package io.hhplus.conbook.infra.db.client;
+
+import io.hhplus.conbook.domain.client.NotifactionLog;
+import io.hhplus.conbook.domain.client.NotificationLogRepository;
+import io.hhplus.conbook.interfaces.api.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationLogRepositoryImpl implements NotificationLogRepository {
+
+    private final NotificationLogJpaRepository notificationLogJpaRepository;
+
+    @Override
+    public NotifactionLog save(NotifactionLog log) {
+        return notificationLogJpaRepository.save(new NotificationLogEntity(log)).toDomain();
+    }
+
+    @Override
+    public NotifactionLog findByBookingId(Long bookingId) {
+        return notificationLogJpaRepository.findByBookingId(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.INTERNAL_SERVER_ERROR.getCode()))
+                .toDomain();
+    }
+}

--- a/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
@@ -1,0 +1,46 @@
+package io.hhplus.conbook.interfaces.event;
+
+import io.hhplus.conbook.application.client.ClientCommand;
+import io.hhplus.conbook.application.client.ClientFacade;
+import io.hhplus.conbook.application.client.ClientLogCommand;
+import io.hhplus.conbook.application.client.ClientLogFacade;
+import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertBookingEventListener {
+
+    private final ClientFacade clientFacade;
+    private final ClientLogFacade clientLogFacade;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleConcertBooking(ConcertBookingEvent event) {
+        log.info("HANDLE - {}", event);
+
+        ClientCommand.Notify command = ClientCommand.Notify.builder()
+                .bookingId(event.getBooking().getId())
+                .concertId(event.getBooking().getSeat().getConcertSchedule().getConcert().getId())
+                .title(event.getBooking().getSeat().getConcertSchedule().getConcert().getTitle())
+                .concertDate(event.getBooking().getSeat().getConcertSchedule().getConcertDate())
+                .seatId(event.getBooking().getSeat().getId())
+                .seatRow(event.getBooking().getSeat().getRowName())
+                .seatNo(event.getBooking().getSeat().getSeatNo())
+                .userId(event.getBooking().getUser().getId())
+                .userName(event.getBooking().getUser().getName())
+                .bookingDateTime(event.getBooking().getCreatedAt())
+                .build();
+
+        clientFacade.notifyBookingHistory(command);
+        clientLogFacade.saveNotificationHistory(new ClientLogCommand.Save(event.getBooking().getId(), LocalDateTime.now()));
+    }
+}

--- a/src/main/java/io/hhplus/conbook/interfaces/schedule/booking/BookingScheduler.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/schedule/booking/BookingScheduler.java
@@ -1,0 +1,32 @@
+package io.hhplus.conbook.interfaces.schedule.booking;
+
+import io.hhplus.conbook.domain.booking.BookingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class BookingScheduler {
+    private final BookingService bookingService;
+    private final TaskScheduler taskScheduler;
+
+    public void addSchedule(long bookingId, long intervalMin) {
+        // 단발성 스케쥴러 등록
+        Runnable task = () -> {
+            log.info("TaskScheduler has been executed for booking[{}]", bookingId);
+
+            bookingService.checkOrUpdate(bookingId);
+        };
+        Instant startTime =
+                LocalDateTime.now().plusMinutes(intervalMin).atZone(ZoneId.systemDefault()).toInstant();
+
+        taskScheduler.schedule(task,startTime);
+    }
+}

--- a/src/main/java/io/hhplus/conbook/interfaces/schedule/token/TokenScheduler.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/schedule/token/TokenScheduler.java
@@ -1,26 +1,18 @@
-package io.hhplus.conbook.config;
+package io.hhplus.conbook.interfaces.schedule.token;
 
-import io.hhplus.conbook.domain.booking.BookingService;
 import io.hhplus.conbook.domain.concert.ConcertService;
 import io.hhplus.conbook.domain.token.TokenManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-
-@Component
 @Slf4j
+@Component
 @RequiredArgsConstructor
-public class ScheduledTaskExecutor {
+public class TokenScheduler {
     private final TokenManager tokenManager;
-    private final BookingService bookingService;
     private final ConcertService concertService;
-    private final TaskScheduler taskScheduler;
 
     /**
      * scheduler interval time : 5min
@@ -37,18 +29,5 @@ public class ScheduledTaskExecutor {
             tokenManager.clearNonValidTokens(concertId);
             tokenManager.convertToPass(concertId);
         }
-    }
-
-    public void addSchedule(long bookingId, long intervalMin) {
-        // 단발성 스케쥴러 등록
-        Runnable task = () -> {
-            log.info("\nTaskScheduler has been executed");
-
-            bookingService.checkOrUpdate(bookingId);
-        };
-        Instant startTime =
-                LocalDateTime.now().plusMinutes(intervalMin).atZone(ZoneId.systemDefault()).toInstant();
-
-        taskScheduler.schedule(task,startTime);
     }
 }

--- a/src/test/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisherTest.java
+++ b/src/test/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisherTest.java
@@ -1,0 +1,44 @@
+package io.hhplus.conbook.application.event;
+
+import io.hhplus.conbook.infra.db.client.NotificationLogEntity;
+import io.hhplus.conbook.infra.db.client.NotificationLogJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ConcertBookingEventPublisherTest {
+
+    @Autowired
+    ConcertBookingEventPublisherTestSupporter eventPublisher;
+    @Autowired
+    NotificationLogJpaRepository notificationLogJpaRepository;
+
+    @BeforeEach
+    void clear() {
+        notificationLogJpaRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("[정상]: 좌석예약 시 이벤트가 정상적으로 발생시키고 처리한다.")
+    void publishConcertBookingEvent() throws Exception {
+        // given
+        long bookingId = 1L;
+
+        // when
+        eventPublisher.publishEventInTransaction(bookingId);
+
+        // then
+        System.out.println("WAIT");
+        Thread.sleep(500);
+
+        Optional<NotificationLogEntity> foundLog = notificationLogJpaRepository.findByBookingId(bookingId);
+        assertThat(foundLog.isPresent()).isTrue();
+    }
+}

--- a/src/test/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisherTestSupporter.java
+++ b/src/test/java/io/hhplus/conbook/application/event/ConcertBookingEventPublisherTestSupporter.java
@@ -1,0 +1,44 @@
+package io.hhplus.conbook.application.event;
+
+import io.hhplus.conbook.domain.booking.Booking;
+import io.hhplus.conbook.domain.booking.BookingStatus;
+import io.hhplus.conbook.infra.db.booking.BookingEntity;
+import io.hhplus.conbook.infra.db.booking.BookingJpaRepository;
+import io.hhplus.conbook.infra.db.concert.SeatEntity;
+import io.hhplus.conbook.infra.db.concert.SeatJpaRepository;
+import io.hhplus.conbook.infra.db.user.UserEntity;
+import io.hhplus.conbook.infra.db.user.UserJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * ConcertBookingEvent의 Publisher & Listener의 테스트용 클래스
+ * - 테스트를 수행하는 클래스 내부에 @Transactional을 추가한 메서드를 돌릴 때 별도의 트랜잭션을 가질 수 없음.
+ */
+@Component
+public class ConcertBookingEventPublisherTestSupporter {
+    @Autowired
+    ConcertBookingEventPublisher eventPublisher;
+    @Autowired
+    BookingJpaRepository bookingJpaRepository;
+    @Autowired
+    SeatJpaRepository seatJpaRepository;
+    @Autowired
+    UserJpaRepository userJpaRepository;
+
+    @Transactional
+    void publishEventInTransaction(long bookingId) {
+        SeatEntity seat = seatJpaRepository.findById(30L).get();
+        UserEntity user = userJpaRepository.findById(1L).get();
+        Booking booking = new Booking(seat.toDomain(), user.toDomain(), BookingStatus.RESERVED);
+        ReflectionTestUtils.setField(booking, "id", bookingId);
+
+        Booking bookingResult = bookingJpaRepository.findById(bookingId)
+                .orElse(new BookingEntity(booking))
+                .toDomain();
+
+        eventPublisher.publishEventOn(bookingResult);
+    }
+}

--- a/src/test/java/io/hhplus/conbook/domain/token/TokenManagerTest.java
+++ b/src/test/java/io/hhplus/conbook/domain/token/TokenManagerTest.java
@@ -1,11 +1,11 @@
 package io.hhplus.conbook.domain.token;
 
-import io.hhplus.conbook.config.ScheduledTaskExecutor;
 import io.hhplus.conbook.domain.concert.Concert;
 import io.hhplus.conbook.domain.concert.ConcertService;
 import io.hhplus.conbook.domain.token.generation.TokenType;
 import io.hhplus.conbook.domain.user.User;
 import io.hhplus.conbook.domain.user.UserService;
+import io.hhplus.conbook.interfaces.schedule.token.TokenScheduler;
 import io.hhplus.conbook.performance.token.infra.db.TokenJpaRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,11 +13,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 class TokenManagerTest {
@@ -34,7 +32,7 @@ class TokenManagerTest {
     TokenJpaRepository tokenJpaRepository;
 
     @Autowired
-    ScheduledTaskExecutor scheduledTaskExecutor;
+    TokenScheduler tokenScheduler;
 
     @BeforeEach
     void init() {
@@ -143,7 +141,7 @@ class TokenManagerTest {
 //        ReflectionTestUtils.setField(queue, "accessCapacity", 2);
 //        tokenQueueJpaRepository.save(queue);
 //
-//        scheduledTaskExecutor.updateQueueList();
+//        tokenScheduler.updateQueueList();
 //
 //        //when
 //        TokenStatusInfo waitingInfo = tokenManager.getWaitingStatusInfo(token.jwt());

--- a/src/test/java/io/hhplus/conbook/infra/client/FileSysClientServiceTest.java
+++ b/src/test/java/io/hhplus/conbook/infra/client/FileSysClientServiceTest.java
@@ -1,0 +1,62 @@
+package io.hhplus.conbook.infra.client;
+
+import io.hhplus.conbook.domain.client.BookingHistory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FileSysClientServiceTest {
+    @Autowired
+    FileSysClientService fileSysClientService;
+
+    @BeforeEach
+    void clear() {
+        System.out.println("=== CLEAR ===");
+        String month = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        File historyDir = new File(FileSysClientService.CONTEXT_PATH + File.separator + month);
+
+        if (historyDir.exists()) {
+            for (File file : historyDir.listFiles()) {
+                file.delete();
+            }
+            historyDir.delete();
+        }
+    }
+
+    @Test
+    @DisplayName("[정상]: 예약정보를 파일시스템에 파일로 생성 (외부 API의 기능으로 가정)")
+    void saveBookingHistoryFromService() {
+        // given
+        BookingHistory history = BookingHistory.builder()
+                .bookingId(1L)
+                .concertId(1L)
+                .title("[TEST]: concert")
+                .concertDate(LocalDate.now().minusDays(10))
+                .seatId(1L)
+                .seatRow("A")
+                .seatNo(1)
+                .userId(1L)
+                .userName("james")
+                .bookingDateTime(LocalDateTime.now())
+                .build();
+
+        // when
+        fileSysClientService.notifyBookingHistory(history);
+
+        // then
+        String month = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        File historyDir = new File(FileSysClientService.CONTEXT_PATH + File.separator + month);
+
+        assertThat(historyDir.exists()).isTrue();
+    }
+}

--- a/src/test/java/io/hhplus/conbook/infra/db/client/NotificationLogJpaRepositoryTest.java
+++ b/src/test/java/io/hhplus/conbook/infra/db/client/NotificationLogJpaRepositoryTest.java
@@ -1,0 +1,22 @@
+package io.hhplus.conbook.infra.db.client;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NotificationLogJpaRepositoryTest {
+    @Autowired
+    NotificationLogJpaRepository notificationLogJpaRepository;
+
+    @Test
+    @DisplayName("[정상]: JPA 쿼리 확인 - 저장된 알림 로그 확인")
+    void queryForNotifaciotn() {
+        // given
+        long bookindId = 1;
+
+        // when
+        notificationLogJpaRepository.findByBookingId(bookindId);
+    }
+}

--- a/src/test/resources/schema-cleanup.sql
+++ b/src/test/resources/schema-cleanup.sql
@@ -7,3 +7,4 @@ drop table if exists concert
 drop table if exists user_point
 drop table if exists users
 drop table if exists token
+drop table if exists notification_log

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -91,6 +91,17 @@ create table token
     primary key (id)
 );
 
+create table notification_log
+(
+    id            bigint    not null auto_increment,
+    booking_id    bigint,
+    finished_at    datetime(6),
+    primary key (id)
+) engine=InnoDB;
+
+alter table if exists notification_log
+    add constraint UKnotificationid unique (id);
+
 alter table if exists payment
     add constraint UKku02qy6369hn9uhy3n7jk9v6e unique (booking_id);
 


### PR DESCRIPTION
### 변경 내역
- 서비스 분리 시 예상되는 문제점과 해결 방안 보고서 [7709610734505220086ffeb79f8881d3fc07a906]
- 예약정보를 저장하는 부가기능 구현 [2773a9d577b27790437c39e6f07a1d9d074aadb4, 277a9d6adf0a9c863bbe259a529360febb8171b0, c27681efd18c06c95b95117a099f4365e3581265]
- 기존 기능과 독릭적으로 수행되도록 부가기능 적용 [2137b83ef0af3a232fd0d02fc8d5834bbf856cdb]
- 스케쥴러 역할 분리

### 리뷰 포인트 
- 챕터2를 진행할 때도 생각했던 것인데, 콘서트와 예약 도메인으로 나뉘어져 있을 때 콘서트를 예약하는 유즈케이스(ConcertBooking)는 어떤 도메인에 포함시키는게 맞는걸까요?? 액션 자체는 '예약'이기 때문에 예약 (Booking) 도메인에 넣으려 했으나 그 대상은 콘서트이기 때문에 concert에 넣었지만 볼 때 마다 확신이 들지 않습니다. [2137b83ef0af3a232fd0d02fc8d5834bbf856cdb - ConcertBooking]

- 동일한 비즈니스 로직을 수행하고 있고 구분할만한 이름이 생각나지 않아서 application레이어와 service레이어에서 동일한 메서드 이름(notifyBookingHistory())을 사용했습니다. 레이어별로 메서드명을 다르게하는게 맞다고 들었는데 같게하면 안되는 걸까요??? [2773a9d577b27790437c39e6f07a1d9d074aadb4]

- Event publisher와 listener가 제대로 동작하는지 확인하는 테스트 코드는 일반적으로 어떻게 짜는게 좋을까요??
  @Test 메서드가 있는 클래스의 다른 메서드에 @Transactional을 붙여도 정상적으로 트랜잭션이 적용 안되어서 ~TestSupporter라는 별도의 클래스를 만들었습니다. [4f7d7e8604fe8c1a938e5cdc9acbae2d849b69eb]
   