### PR TITLE
STEP 17: 카프카 Application 연동 및 프레임워크에 적합하게 연동테스트 진행

### DIFF
--- a/Docker_execute_note.md
+++ b/Docker_execute_note.md
@@ -1,0 +1,11 @@
+### how to start docker containers
+
+- default
+```text
+$ docker-compose up -d
+```
+
+- separately
+```text
+$ docker-compose -p conbook up -d
+```

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 	// redis - lettuce
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 
@@ -47,6 +48,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:kafka:1.20.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,14 +36,17 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// redis - lettuce
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	// additional
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
-	// redis - lettuce
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  redis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "6379:6379"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,16 @@ spring:
       group-id: conbook.concert-booking.notification
       auto-offset-reset: earliest
       bootstrap-servers: localhost:9092
-      key-deserializer: org.apache.kafka.common.serialization.StringSerializer
-      value-deserializer: org.apache.kafka.common.serialization.StringSerializer
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     producer:
       bootstrap-servers: localhost:9092
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+kafka:
+  topic:
+    concert: concert-booking.created
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,19 @@ spring:
         show_sql: true
         format_sql: true
     database-platform: org.hibernate.dialect.MariaDBDialect
+
+  kafka:
+    consumer:
+      group-id: conbook.concert-booking.notification
+      auto-offset-reset: earliest
+      bootstrap-servers: localhost:9092
+      key-deserializer: org.apache.kafka.common.serialization.StringSerializer
+      value-deserializer: org.apache.kafka.common.serialization.StringSerializer
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
 springdoc:
   swagger-ui:
     tags-sorter: alpha

--- a/src/test/java/io/hhplus/conbook/testcontainers/KafkaContainerBuilder.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/KafkaContainerBuilder.java
@@ -1,0 +1,30 @@
+package io.hhplus.conbook.testcontainers;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@TestPropertySource(
+        properties = {
+                "spring.kafka.consumer.auto-offset-reset=earliest"
+        }
+)
+@Testcontainers
+public abstract class KafkaContainerBuilder {
+
+    @Container
+    static final KafkaContainer kafkaContainer = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:latest")
+    );
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafkaContainer::getBootstrapServers);
+    }
+}

--- a/src/test/java/io/hhplus/conbook/testcontainers/KafkaContainerBuilderTest.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/KafkaContainerBuilderTest.java
@@ -1,0 +1,35 @@
+package io.hhplus.conbook.testcontainers;
+
+import io.hhplus.conbook.testcontainers.kafka.KafkaTestConsumer;
+import io.hhplus.conbook.testcontainers.kafka.KafkaTestProducer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaContainerBuilderTest extends KafkaContainerBuilder {
+
+    @Autowired
+    KafkaTestProducer testProducer;
+    @Autowired
+    KafkaTestConsumer testConsumer;
+
+    @Test
+    @DisplayName("[정상] Kafka 연동 테스트")
+    void kafkaConnectionTest() throws InterruptedException {
+        //given & when
+        String message = "";
+
+        for (int i = 0; i < 5; i++) {
+            message = "[MESSAGE] produced at " + i;
+            testProducer.produce(message);
+        }
+
+        // then
+        Thread.sleep(10000); // 10초 대기 (consumer의 메시지 처리시간을 기다려준다.)
+        String lastReceivedMessage = testConsumer.getReceivedMessage();
+
+        assertThat(lastReceivedMessage).isEqualTo(message);
+    }
+}

--- a/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestConsumer.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestConsumer.java
@@ -1,0 +1,19 @@
+package io.hhplus.conbook.testcontainers.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaTestConsumer {
+    private String receivedMessage;
+
+    public String getReceivedMessage() {
+        return receivedMessage;
+    }
+
+    @KafkaListener(topics = "${kafka.topic.concert}")
+    public void listen(String message) {
+        System.out.println("[RECEIVED]: " + message);
+        receivedMessage = message;
+    }
+}

--- a/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestProducer.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestProducer.java
@@ -1,0 +1,23 @@
+package io.hhplus.conbook.testcontainers.kafka;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaTestProducer {
+
+    @Value("${kafka.topic.concert}")
+    private String concertTopic;
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaTestProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void produce(String message) {
+        kafkaTemplate.send(concertTopic, message);
+    }
+
+}


### PR DESCRIPTION
### 변경 내역
- 카프카 의존성 추가 [d0ee6c975170df70c91e015eb874954cb1971fbc]
- 카프카 컴포즈 구성 (docker-compose.yml) 및 카프카 설정 정보 설정을 통한 Application 연결 [0b022ed16adf1d645e8a7be43cfbdde061cf2e8d]
- 카프카 토픽 설정 및 컨슈머 디시리얼라이저 변경 [eff8b968fb231cc48ece822421e8c6787ae77611]
- Spring 프레임워크에 맞는 카프카 통합 테스트 [5bbef2fdbf6e77e6377e25393698daae1316d77f]


**테스트 진행 이미지**
1. 테스트용 Producer로 5건의 메시지 전송
![image](https://github.com/user-attachments/assets/7a071154-fd6f-4d44-98f9-7d090670b15d)

2. application.yml에서 지정한 토픽에 대한 브로커에 메시지가 존재하면  해당 메시지 처리
![image](https://github.com/user-attachments/assets/6561055f-8e80-4d95-b9f4-1e56b11ebbd0)

3. 메시지 처리결과
![image](https://github.com/user-attachments/assets/cc0407c2-aae5-44b3-9364-ff3e78dbaa00)

[비고]: testContainers를 사용해서 별도의 브로커를 만들려고 했으나 production에서 사용하는 브로커를 그대로 사용

### 리뷰 포인트
- value-serializer의 경우 StringSerializer를 사용하는 방법과 JsonSerializer를 사용하는 방법 중 어떤게 더 좋을까요?? [eff8b968fb231cc48ece822421e8c6787ae77611]