### PR TITLE
STEP 18: 애플리케이션 이벤트의 카프카 메시지 전환, Outbox Pattern 적용 및 발행실패 케이스 재처리 구현

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -99,6 +99,17 @@ create table notification_log
     primary key (id)
 ) engine=InnoDB;
 
+create table outbox_event
+(
+    retry_count integer not null,
+    created_at  datetime(6),
+    id          bigint  not null auto_increment,
+    event_type  varchar(255),
+    payload     TEXT,
+    status      enum ('CREATED','FAILED','PUBLISHED'),
+    primary key (id)
+) engine=InnoDB;
+
 alter table if exists notification_log
     add constraint UKnotificationid unique (id);
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -101,14 +101,15 @@ create table notification_log
 
 create table outbox_event
 (
-    retry_count integer not null,
-    created_at  datetime(6),
-    id          bigint  not null auto_increment,
-    event_type  varchar(255),
-    payload     TEXT,
-    status      enum ('CREATED','FAILED','PUBLISHED'),
+    retry_count  integer not null,
+    created_at   datetime(6),
+    id           bigint  not null auto_increment,
+    aggregate_id bigint  not null,
+    event_type   varchar(255),
+    payload      TEXT,
+    status       enum ('CREATED','FAILED','PUBLISHED'),
     primary key (id)
-) engine=InnoDB;
+) engine = InnoDB;
 
 alter table if exists notification_log
     add constraint UKnotificationid unique (id);

--- a/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
@@ -1,6 +1,6 @@
 package io.hhplus.conbook.application.client;
 
-import io.hhplus.conbook.domain.booking.Booking;
+import io.hhplus.conbook.application.event.ConcertBookingEvent;
 import io.hhplus.conbook.domain.client.BookingHistory;
 
 import java.time.LocalDate;
@@ -19,18 +19,18 @@ public class ClientCommand {
             String userName,
             LocalDateTime bookingDateTime
     ) {
-        public Notify(Booking booking) {
+        public Notify(ConcertBookingEvent event) {
             this(
-                booking.getId(),
-                booking.getSeat().getConcertSchedule().getConcert().getId(),
-                booking.getSeat().getConcertSchedule().getConcert().getTitle(),
-                booking.getSeat().getConcertSchedule().getConcertDate(),
-                booking.getSeat().getId(),
-                booking.getSeat().getRowName(),
-                booking.getSeat().getSeatNo(),
-                booking.getUser().getId(),
-                booking.getUser().getName(),
-                booking.getCreatedAt()
+                event.getBookingId(),
+                event.getConcertId(),
+                event.getTitle(),
+                event.getConcertDate(),
+                event.getSeatId(),
+                event.getSeatRow(),
+                event.getSeatNo(),
+                event.getUserId(),
+                event.getUserName(),
+                event.getBookingDateTim()
             );
         }
 

--- a/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
+++ b/src/main/java/io/hhplus/conbook/application/client/ClientCommand.java
@@ -1,13 +1,12 @@
 package io.hhplus.conbook.application.client;
 
+import io.hhplus.conbook.domain.booking.Booking;
 import io.hhplus.conbook.domain.client.BookingHistory;
-import lombok.Builder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ClientCommand {
-    @Builder
     public record Notify(
             Long bookingId,
             Long concertId,
@@ -20,6 +19,21 @@ public class ClientCommand {
             String userName,
             LocalDateTime bookingDateTime
     ) {
+        public Notify(Booking booking) {
+            this(
+                booking.getId(),
+                booking.getSeat().getConcertSchedule().getConcert().getId(),
+                booking.getSeat().getConcertSchedule().getConcert().getTitle(),
+                booking.getSeat().getConcertSchedule().getConcertDate(),
+                booking.getSeat().getId(),
+                booking.getSeat().getRowName(),
+                booking.getSeat().getSeatNo(),
+                booking.getUser().getId(),
+                booking.getUser().getName(),
+                booking.getCreatedAt()
+            );
+        }
+
         public BookingHistory toBookingHistory() {
             return BookingHistory.builder()
                     .bookingId(bookingId)

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -9,7 +9,6 @@ import io.hhplus.conbook.domain.concert.ConcertSchedule;
 import io.hhplus.conbook.domain.concert.ConcertService;
 import io.hhplus.conbook.domain.user.User;
 import io.hhplus.conbook.domain.user.UserService;
-import io.hhplus.conbook.interfaces.schedule.booking.BookingScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
@@ -18,15 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 public class ConcertBookingFacade {
-    /**
-     * 예약시 결제 이전까지 점유할 수 있는 시간 - 5분
-     */
-    private final int DEFAULT_BOOKING_STAGING_MIN = 5;
-
     private final UserService userService;
     private final ConcertService concertService;
     private final BookingService bookingService;
-    private final BookingScheduler bookingScheduler;
     private final ConcertBookingEventPublisher concertBookingEventPublisher;
 
     /**
@@ -41,7 +34,6 @@ public class ConcertBookingFacade {
         ConcertSchedule concertSchedule = concertService.getConcertSchedule(booking.concertId(), booking.date());
 
         Booking bookingResult = bookingService.createBooking(concertSchedule, booking.seatId(), user);
-        bookingScheduler.addSchedule(bookingResult.getId(), DEFAULT_BOOKING_STAGING_MIN);
         concertService.updateScheduleStatus(booking.concertId(), booking.date());
 
         concertBookingEventPublisher.publishEventOn(bookingResult);

--- a/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
+++ b/src/main/java/io/hhplus/conbook/application/concert/ConcertBookingFacade.java
@@ -27,7 +27,7 @@ public class ConcertBookingFacade {
      * - 좌석을 미리 안 만들 경우 어떤 식으로 처리할 지는 추후 여유가 있을 때 구현
      *  (좌석의 좌표값(x,y)만 제공될 경우)
      */
-    @CacheEvict(value = "concertSchedules", key = "#serach.concertId")
+    @CacheEvict(value = "concertSchedules", key = "#booking.concertId")
     @Transactional
     public ConcertBookingResult.BookingSeat bookConcertSeat(ConcertBookingCommand.BookingSeat booking) {
         User user = userService.getUserByUUID(booking.userUUID());

--- a/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
+++ b/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
@@ -3,12 +3,14 @@ package io.hhplus.conbook.application.event;
 import io.hhplus.conbook.domain.booking.Booking;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @Getter
+@ToString
 public class ConcertBookingEvent {
     private Long bookingId;
     private Long concertId;

--- a/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
+++ b/src/main/java/io/hhplus/conbook/application/event/ConcertBookingEvent.java
@@ -4,19 +4,33 @@ import io.hhplus.conbook.domain.booking.Booking;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @AllArgsConstructor
 @Getter
 public class ConcertBookingEvent {
+    private Long bookingId;
+    private Long concertId;
+    private String title;
+    private LocalDate concertDate;
+    private Long seatId;
+    private String seatRow;
+    private int seatNo;
+    private Long userId;
+    private String userName;
+    private LocalDateTime bookingDateTim;
 
-//    private Long bookingId;
-//    private Long concertId;
-//    private String title;
-//    private LocalDate concertDate;
-//    private Long seatId;
-//    private String seatRow;
-//    private int seatNo;
-//    private Long userId;
-//    private String userName;
-//    private LocalDateTime bookingDateTime;
-    private Booking booking;
+    public ConcertBookingEvent(Booking b) {
+        this.bookingId = b.getId();
+        this.concertId = b.getSeat().getConcertSchedule().getConcert().getId();
+        this.title = b.getSeat().getConcertSchedule().getConcert().getTitle();
+        this.concertDate = b.getSeat().getConcertSchedule().getConcertDate();
+        this.seatId = b.getSeat().getId();
+        this.seatRow = b.getSeat().getRowName();
+        this.seatNo = b.getSeat().getSeatNo();
+        this.userId = b.getUser().getId();
+        this.userName = b.getUser().getName();
+        this.bookingDateTim = b.getCreatedAt();
+    }
 }

--- a/src/main/java/io/hhplus/conbook/config/KafkaConfig.java
+++ b/src/main/java/io/hhplus/conbook/config/KafkaConfig.java
@@ -1,0 +1,5 @@
+package io.hhplus.conbook.config;
+
+public class KafkaConfig {
+    public static final String TOPIC_CONCERT = "concert-booking.created";
+}

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
@@ -1,0 +1,28 @@
+package io.hhplus.conbook.domain.outbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@Getter @Setter
+public class OutboxEvent {
+    private long id;
+    /** topic */
+    private String eventType;
+    private String payload;
+    private OutboxStatus status;
+    private LocalDateTime createdAt;
+    private int retryCount;
+
+    public OutboxEvent(String eventType, String payload) {
+        this.eventType = eventType;
+        this.payload = payload;
+        status = OutboxStatus.CREATED;
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
@@ -30,4 +30,8 @@ public class OutboxEvent {
     public void changeStatus(OutboxStatus status) {
         this.status = status;
     }
+
+    public void tryAgain() {
+        retryCount++;
+    }
 }

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter @Setter
 public class OutboxEvent {
     private long id;
+    private long aggregateId;
     /** topic */
     private String eventType;
     private String payload;
@@ -19,7 +20,8 @@ public class OutboxEvent {
     private LocalDateTime createdAt;
     private int retryCount;
 
-    public OutboxEvent(String eventType, String payload) {
+    public OutboxEvent(long aggregateId, String eventType, String payload) {
+        this.aggregateId = aggregateId;
         this.eventType = eventType;
         this.payload = payload;
         status = OutboxStatus.CREATED;

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEvent.java
@@ -3,13 +3,12 @@ package io.hhplus.conbook.domain.outbox;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Builder
 @AllArgsConstructor
-@Getter @Setter
+@Getter
 public class OutboxEvent {
     private long id;
     private long aggregateId;
@@ -26,5 +25,9 @@ public class OutboxEvent {
         this.payload = payload;
         status = OutboxStatus.CREATED;
         createdAt = LocalDateTime.now();
+    }
+
+    public void changeStatus(OutboxStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
@@ -1,0 +1,47 @@
+package io.hhplus.conbook.domain.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import io.hhplus.conbook.config.KafkaConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OutboxEventStore {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private OutboxRepository outboxRepository;
+    /**
+     * saveOrUpdate (merge)
+     */
+    @Transactional
+    public void save(ConcertBookingEvent event) {
+        String payload = "";
+        try {
+            payload = mapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+        }
+        outboxRepository.save(new OutboxEvent(event.getBookingId(), KafkaConfig.TOPIC_CONCERT, payload));
+    }
+
+    public List<OutboxEvent> findFailedList() {
+        return outboxRepository.findByStatus(OutboxStatus.FAILED);
+    }
+
+    @Transactional
+    public void updateAs(long aggregateId, OutboxStatus status) {
+        OutboxEvent event = outboxRepository.getByAggregateId(aggregateId);
+
+        event.changeStatus(status);
+        outboxRepository.save(event);
+    }
+}

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class OutboxEventStore {
 
-    private OutboxRepository outboxRepository;
+    private final OutboxRepository outboxRepository;
     /**
      * saveOrUpdate (merge)
      */

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxEventStore.java
@@ -33,9 +33,7 @@ public class OutboxEventStore {
     @Transactional
     public void updateAs(long aggregateId, OutboxStatus status) {
         OutboxEvent event = outboxRepository.getByAggregateId(aggregateId);
-
         event.changeStatus(status);
-        if (status.equals(OutboxStatus.FAILED)) event.tryAgain();
 
         outboxRepository.save(event);
     }

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxRepository.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxRepository.java
@@ -1,0 +1,9 @@
+package io.hhplus.conbook.domain.outbox;
+
+import java.util.List;
+
+public interface OutboxRepository {
+    void save(OutboxEvent outboxEvent);
+    List<OutboxEvent> findByStatus(OutboxStatus status);
+    OutboxEvent getByAggregateId(long aggregateId);
+}

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxStatus.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.conbook.domain.outbox;
+
+public enum OutboxStatus {
+    CREATED, PUBLISHED, FAILED
+}

--- a/src/main/java/io/hhplus/conbook/domain/outbox/OutboxStatus.java
+++ b/src/main/java/io/hhplus/conbook/domain/outbox/OutboxStatus.java
@@ -1,5 +1,5 @@
 package io.hhplus.conbook.domain.outbox;
 
 public enum OutboxStatus {
-    CREATED, PUBLISHED, FAILED
+    CREATED, PUBLISHED, FAILED, ABANDONED;
 }

--- a/src/main/java/io/hhplus/conbook/infra/db/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/OutboxRepositoryImpl.java
@@ -1,0 +1,38 @@
+package io.hhplus.conbook.infra.db;
+
+import io.hhplus.conbook.domain.outbox.OutboxEvent;
+import io.hhplus.conbook.domain.outbox.OutboxRepository;
+import io.hhplus.conbook.domain.outbox.OutboxStatus;
+import io.hhplus.conbook.infra.db.outbox.OutboxEventEntity;
+import io.hhplus.conbook.infra.db.outbox.OutboxJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public void save(OutboxEvent outboxEvent) {
+        outboxJpaRepository.save(new OutboxEventEntity(outboxEvent));
+    }
+
+    @Override
+    public List<OutboxEvent> findByStatus(OutboxStatus status) {
+        return outboxJpaRepository.findByStatus(status)
+                .stream()
+                .map(OutboxEventEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public OutboxEvent getByAggregateId(long aggregateId) {
+        return outboxJpaRepository.findByAggregateId(aggregateId)
+                .orElseThrow()
+                .toDomain();
+    }
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/booking/BookingJpaRepository.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/booking/BookingJpaRepository.java
@@ -1,6 +1,21 @@
 package io.hhplus.conbook.infra.db.booking;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface BookingJpaRepository extends JpaRepository<BookingEntity, Long> {
+
+    @Query("""
+        SELECT b FROM BookingEntity b
+        JOIN FETCH b.user u
+        JOIN FETCH b.seat s
+        JOIN FETCH s.concertSchedule cs
+        JOIN FETCH cs.concert c
+        WHERE
+            b.id = :id
+    """)
+    @Override
+    Optional<BookingEntity> findById(Long id);
 }

--- a/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxEventEntity.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxEventEntity.java
@@ -1,0 +1,52 @@
+package io.hhplus.conbook.infra.db.outbox;
+
+import io.hhplus.conbook.domain.outbox.OutboxEvent;
+import io.hhplus.conbook.domain.outbox.OutboxStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "outbox_event")
+@Entity
+@Getter
+@NoArgsConstructor
+public class OutboxEventEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    /** topic */
+    private String eventType;
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    private OutboxStatus status;
+
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    private int retryCount;
+
+    public OutboxEvent toDomain() {
+        return OutboxEvent.builder()
+                .id(id)
+                .eventType(eventType)
+                .payload(payload)
+                .status(status)
+                .createdAt(createdAt)
+                .retryCount(retryCount)
+                .build();
+    }
+
+    public OutboxEventEntity(OutboxEvent event) {
+        this.id = event.getId();
+        this.eventType = event.getEventType();
+        this.payload = event.getPayload();
+        this.status = event.getStatus();
+        this.createdAt = event.getCreatedAt();
+        this.retryCount = event.getRetryCount();
+    }
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxEventEntity.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxEventEntity.java
@@ -14,7 +14,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class OutboxEventEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
+
+    private long aggregateId;
 
     /** topic */
     private String eventType;
@@ -33,6 +35,7 @@ public class OutboxEventEntity {
     public OutboxEvent toDomain() {
         return OutboxEvent.builder()
                 .id(id)
+                .aggregateId(aggregateId)
                 .eventType(eventType)
                 .payload(payload)
                 .status(status)
@@ -43,6 +46,7 @@ public class OutboxEventEntity {
 
     public OutboxEventEntity(OutboxEvent event) {
         this.id = event.getId();
+        this.aggregateId = event.getAggregateId();
         this.eventType = event.getEventType();
         this.payload = event.getPayload();
         this.status = event.getStatus();

--- a/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxJpaRepository.java
@@ -1,0 +1,13 @@
+package io.hhplus.conbook.infra.db.outbox;
+
+import io.hhplus.conbook.domain.outbox.OutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OutboxJpaRepository extends JpaRepository<OutboxEventEntity, Long> {
+    List<OutboxEventEntity> findByStatus(OutboxStatus status);
+
+    Optional<OutboxEventEntity> findByAggregateId(Long aggregateId);
+}

--- a/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/conbook/infra/db/outbox/OutboxRepositoryImpl.java
@@ -1,10 +1,8 @@
-package io.hhplus.conbook.infra.db;
+package io.hhplus.conbook.infra.db.outbox;
 
 import io.hhplus.conbook.domain.outbox.OutboxEvent;
 import io.hhplus.conbook.domain.outbox.OutboxRepository;
 import io.hhplus.conbook.domain.outbox.OutboxStatus;
-import io.hhplus.conbook.infra.db.outbox.OutboxEventEntity;
-import io.hhplus.conbook.infra.db.outbox.OutboxJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
+++ b/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
@@ -1,13 +1,13 @@
 package io.hhplus.conbook.infra.kafka.producer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.hhplus.conbook.application.event.ConcertBookingEvent;
 import io.hhplus.conbook.config.KafkaConfig;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KafkaConcertBookingProducer {
@@ -16,14 +16,7 @@ public class KafkaConcertBookingProducer {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    public void send(ConcertBookingEvent event) {
-        String message;
-        try {
-            message = mapper.writeValueAsString(event);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-
+    public void send(String message) {
         kafkaTemplate.send(KafkaConfig.TOPIC_CONCERT, message);
     }
 }

--- a/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
+++ b/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
@@ -3,17 +3,14 @@ package io.hhplus.conbook.infra.kafka.producer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import io.hhplus.conbook.config.KafkaConfig;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class KafkaConcertBookingProducer {
-
-    @Value("${kafka.topic.concert}")
-    private String concertTopic;
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
@@ -27,6 +24,6 @@ public class KafkaConcertBookingProducer {
             throw new RuntimeException(e);
         }
 
-        kafkaTemplate.send(concertTopic, message);
+        kafkaTemplate.send(KafkaConfig.TOPIC_CONCERT, message);
     }
 }

--- a/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
+++ b/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
@@ -2,7 +2,7 @@ package io.hhplus.conbook.infra.kafka.producer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.hhplus.conbook.application.client.ClientCommand;
+import io.hhplus.conbook.application.event.ConcertBookingEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -19,10 +19,10 @@ public class KafkaConcertBookingProducer {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
-    public void send(ClientCommand.Notify notification){
+    public void send(ConcertBookingEvent event) {
         String message;
         try {
-            message = mapper.writeValueAsString(notification);
+            message = mapper.writeValueAsString(event);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
+++ b/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
@@ -1,0 +1,32 @@
+package io.hhplus.conbook.infra.kafka.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.conbook.application.client.ClientCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaConcertBookingProducer {
+
+    @Value("${kafka.topic.concert}")
+    private String concertTopic;
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public void send(ClientCommand.Notify notification){
+        String message;
+        try {
+            message = mapper.writeValueAsString(notification);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        kafkaTemplate.send(concertTopic, message);
+    }
+}

--- a/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
+++ b/src/main/java/io/hhplus/conbook/infra/kafka/producer/KafkaConcertBookingProducer.java
@@ -14,8 +14,6 @@ public class KafkaConcertBookingProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    private final ObjectMapper mapper = new ObjectMapper();
-
     public void send(String message) {
         kafkaTemplate.send(KafkaConfig.TOPIC_CONCERT, message);
     }

--- a/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
@@ -6,6 +6,7 @@ import io.hhplus.conbook.application.client.ClientCommand;
 import io.hhplus.conbook.application.client.ClientFacade;
 import io.hhplus.conbook.application.client.ClientLogCommand;
 import io.hhplus.conbook.application.client.ClientLogFacade;
+import io.hhplus.conbook.application.event.ConcertBookingEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -27,7 +28,9 @@ public class KafkaConcertBookingConsumer {
     public void listen(String message) throws JsonProcessingException {
         log.info("[RECEIVED] message: {}", message);
 
-        ClientCommand.Notify command = objectMapper.readValue(message, ClientCommand.Notify.class);
+        ClientCommand.Notify command
+                = new ClientCommand.Notify(objectMapper.readValue(message, ConcertBookingEvent.class));
+
         clientFacade.notifyBookingHistory(command);
         clientLogFacade.saveNotificationHistory(new ClientLogCommand.Save(command.bookingId(), LocalDateTime.now()));
     }

--- a/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
@@ -1,0 +1,34 @@
+package io.hhplus.conbook.interfaces.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.conbook.application.client.ClientCommand;
+import io.hhplus.conbook.application.client.ClientFacade;
+import io.hhplus.conbook.application.client.ClientLogCommand;
+import io.hhplus.conbook.application.client.ClientLogFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaConcertBookingConsumer {
+
+    private ClientFacade clientFacade;
+    private ClientLogFacade clientLogFacade;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @KafkaListener(topics = "${kafka.topic.concert}")
+    public void listen(String message) throws JsonProcessingException {
+        log.info("[RECEIVED] message: {}", message);
+
+        ClientCommand.Notify command = objectMapper.readValue(message, ClientCommand.Notify.class);
+        clientFacade.notifyBookingHistory(command);
+        clientLogFacade.saveNotificationHistory(new ClientLogCommand.Save(command.bookingId(), LocalDateTime.now()));
+    }
+}

--- a/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/consumer/KafkaConcertBookingConsumer.java
@@ -7,6 +7,7 @@ import io.hhplus.conbook.application.client.ClientFacade;
 import io.hhplus.conbook.application.client.ClientLogCommand;
 import io.hhplus.conbook.application.client.ClientLogFacade;
 import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import io.hhplus.conbook.config.KafkaConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -24,7 +25,7 @@ public class KafkaConcertBookingConsumer {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @KafkaListener(topics = "${kafka.topic.concert}")
+    @KafkaListener(topics = KafkaConfig.TOPIC_CONCERT)
     public void listen(String message) throws JsonProcessingException {
         log.info("[RECEIVED] message: {}", message);
 

--- a/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
@@ -1,50 +1,22 @@
 package io.hhplus.conbook.interfaces.event;
 
 import io.hhplus.conbook.application.client.ClientCommand;
-import io.hhplus.conbook.application.client.ClientFacade;
-import io.hhplus.conbook.application.client.ClientLogCommand;
-import io.hhplus.conbook.application.client.ClientLogFacade;
 import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import io.hhplus.conbook.infra.kafka.producer.KafkaConcertBookingProducer;
 import io.hhplus.conbook.interfaces.schedule.booking.BookingScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ConcertBookingEventListener {
 
-    private final ClientFacade clientFacade;
-    private final ClientLogFacade clientLogFacade;
     private final BookingScheduler bookingScheduler;
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleConcertBooking(ConcertBookingEvent event) {
-        log.info("HANDLE - {}", event);
-
-        ClientCommand.Notify command = ClientCommand.Notify.builder()
-                .bookingId(event.getBooking().getId())
-                .concertId(event.getBooking().getSeat().getConcertSchedule().getConcert().getId())
-                .title(event.getBooking().getSeat().getConcertSchedule().getConcert().getTitle())
-                .concertDate(event.getBooking().getSeat().getConcertSchedule().getConcertDate())
-                .seatId(event.getBooking().getSeat().getId())
-                .seatRow(event.getBooking().getSeat().getRowName())
-                .seatNo(event.getBooking().getSeat().getSeatNo())
-                .userId(event.getBooking().getUser().getId())
-                .userName(event.getBooking().getUser().getName())
-                .bookingDateTime(event.getBooking().getCreatedAt())
-                .build();
-
-        clientFacade.notifyBookingHistory(command);
-        clientLogFacade.saveNotificationHistory(new ClientLogCommand.Save(event.getBooking().getId(), LocalDateTime.now()));
-    }
+    private final KafkaConcertBookingProducer kafkaConcertBookingProducer;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleForSchedule(ConcertBookingEvent event) {
@@ -52,5 +24,13 @@ public class ConcertBookingEventListener {
 
         int DEFAULT_BOOKING_STAGING_MIN = 5;
         bookingScheduler.addSchedule(event.getBooking().getId(), DEFAULT_BOOKING_STAGING_MIN);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleForMessaging(ConcertBookingEvent event) {
+        log.info("[MESSAGING] HANDLE - {}", event);
+
+        ClientCommand.Notify notification = new ClientCommand.Notify(event.getBooking());
+        kafkaConcertBookingProducer.send(notification);
     }
 }

--- a/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
@@ -1,11 +1,13 @@
 package io.hhplus.conbook.interfaces.event;
 
-import io.hhplus.conbook.application.client.ClientCommand;
 import io.hhplus.conbook.application.event.ConcertBookingEvent;
+import io.hhplus.conbook.domain.outbox.OutboxEventStore;
+import io.hhplus.conbook.domain.outbox.OutboxStatus;
 import io.hhplus.conbook.infra.kafka.producer.KafkaConcertBookingProducer;
 import io.hhplus.conbook.interfaces.schedule.booking.BookingScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -16,21 +18,34 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ConcertBookingEventListener {
 
     private final BookingScheduler bookingScheduler;
+    private final OutboxEventStore outboxEventStore;
     private final KafkaConcertBookingProducer kafkaConcertBookingProducer;
 
+    @Order(1)
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void handleForSchedule(ConcertBookingEvent event) {
         log.info("[SCHEDULE] HANDLE - {}", event);
 
         int DEFAULT_BOOKING_STAGING_MIN = 5;
-        bookingScheduler.addSchedule(event.getBooking().getId(), DEFAULT_BOOKING_STAGING_MIN);
+        bookingScheduler.addSchedule(event.getBookingId(), DEFAULT_BOOKING_STAGING_MIN);
+    }
+
+    @Order(2)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleForOutbox(ConcertBookingEvent event) {
+        log.info("[OUTBOX] HANDLE - {}", event);
+        outboxEventStore.save(event);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleForMessaging(ConcertBookingEvent event) {
         log.info("[MESSAGING] HANDLE - {}", event);
 
-        ClientCommand.Notify notification = new ClientCommand.Notify(event.getBooking());
-        kafkaConcertBookingProducer.send(notification);
+        try {
+            kafkaConcertBookingProducer.send(event);
+            outboxEventStore.updateAs(event.getBookingId(), OutboxStatus.PUBLISHED);
+        } catch (Exception e) {
+            outboxEventStore.updateAs(event.getBookingId(), OutboxStatus.FAILED);
+        }
     }
 }

--- a/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/event/ConcertBookingEventListener.java
@@ -12,6 +12,7 @@ import io.hhplus.conbook.util.JsonUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -44,6 +45,7 @@ public class ConcertBookingEventListener {
         outboxEventStore.save(new OutboxEvent(event.getBookingId(), KafkaConfig.TOPIC_CONCERT, payload));
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleForMessaging(ConcertBookingEvent event) {
         log.info("[MESSAGING] HANDLE - {}", event);

--- a/src/main/java/io/hhplus/conbook/interfaces/schedule/concert/ConcertBookingScheduler.java
+++ b/src/main/java/io/hhplus/conbook/interfaces/schedule/concert/ConcertBookingScheduler.java
@@ -1,0 +1,42 @@
+package io.hhplus.conbook.interfaces.schedule.concert;
+
+import io.hhplus.conbook.domain.outbox.OutboxEvent;
+import io.hhplus.conbook.domain.outbox.OutboxEventStore;
+import io.hhplus.conbook.domain.outbox.OutboxStatus;
+import io.hhplus.conbook.infra.kafka.producer.KafkaConcertBookingProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertBookingScheduler {
+
+    private final OutboxEventStore outboxEventStore;
+    private final KafkaConcertBookingProducer kafkaConcertBookingProducer;
+
+    @Scheduled(fixedDelay = 5000)
+    public void sendingMessage() {
+        List<OutboxEvent> failedEvents = outboxEventStore.findFailedList();
+
+        if (failedEvents.isEmpty()) return;
+
+        for (OutboxEvent failedEvent : failedEvents) {
+            failedEvent.tryAgain();
+
+            try {
+                String message = failedEvent.getPayload();
+                kafkaConcertBookingProducer.send(message);
+                failedEvent.changeStatus(OutboxStatus.PUBLISHED);
+            } catch (Exception e) {
+                if (failedEvent.getRetryCount() > 10) failedEvent.changeStatus(OutboxStatus.ABANDONED);
+                log.error(e.getMessage());
+            }
+            outboxEventStore.save(failedEvent);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/conbook/util/JsonUtil.java
+++ b/src/main/java/io/hhplus/conbook/util/JsonUtil.java
@@ -1,0 +1,19 @@
+package io.hhplus.conbook.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JsonUtil {
+
+    public static <T> String toJson(T obj) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/conbook/util/JsonUtil.java
+++ b/src/main/java/io/hhplus/conbook/util/JsonUtil.java
@@ -2,6 +2,7 @@ package io.hhplus.conbook.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -9,6 +10,7 @@ public class JsonUtil {
 
     public static <T> String toJson(T obj) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
         try {
             return mapper.writeValueAsString(obj);
         } catch (JsonProcessingException e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,10 +28,6 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
-kafka:
-  topic:
-    concert: concert-booking.created
-
 springdoc:
   swagger-ui:
     tags-sorter: alpha

--- a/src/test/java/io/hhplus/conbook/infra/db/booking/BookingJpaRepositoryTest.java
+++ b/src/test/java/io/hhplus/conbook/infra/db/booking/BookingJpaRepositoryTest.java
@@ -1,0 +1,22 @@
+package io.hhplus.conbook.infra.db.booking;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BookingJpaRepositoryTest {
+
+    @Autowired
+    BookingJpaRepository bookingJpaRepository;
+
+    @Test
+    @DisplayName("[정상]: JPA 쿼리확인 - 예약정보 조회 확인")
+    void jpaQueryDisplayBooking() {
+        // given
+        long id = 1;
+
+        bookingJpaRepository.findById(id);
+    }
+}

--- a/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestConsumer.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestConsumer.java
@@ -1,5 +1,6 @@
 package io.hhplus.conbook.testcontainers.kafka;
 
+import io.hhplus.conbook.config.KafkaConfig;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,7 @@ public class KafkaTestConsumer {
         return receivedMessage;
     }
 
-    @KafkaListener(topics = "${kafka.topic.concert}")
+    @KafkaListener(topics = KafkaConfig.TOPIC_CONCERT)
     public void listen(String message) {
         System.out.println("[RECEIVED]: " + message);
         receivedMessage = message;

--- a/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestProducer.java
+++ b/src/test/java/io/hhplus/conbook/testcontainers/kafka/KafkaTestProducer.java
@@ -1,14 +1,11 @@
 package io.hhplus.conbook.testcontainers.kafka;
 
-import org.springframework.beans.factory.annotation.Value;
+import io.hhplus.conbook.config.KafkaConfig;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 public class KafkaTestProducer {
-
-    @Value("${kafka.topic.concert}")
-    private String concertTopic;
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
@@ -17,7 +14,7 @@ public class KafkaTestProducer {
     }
 
     public void produce(String message) {
-        kafkaTemplate.send(concertTopic, message);
+        kafkaTemplate.send(KafkaConfig.TOPIC_CONCERT, message);
     }
 
 }

--- a/src/test/resources/schema-cleanup.sql
+++ b/src/test/resources/schema-cleanup.sql
@@ -8,3 +8,4 @@ drop table if exists user_point
 drop table if exists users
 drop table if exists token
 drop table if exists notification_log
+drop table if exists outbox_event

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -99,6 +99,17 @@ create table notification_log
     primary key (id)
 ) engine=InnoDB;
 
+create table outbox_event
+(
+    retry_count integer not null,
+    created_at  datetime(6),
+    id          bigint  not null auto_increment,
+    event_type  varchar(255),
+    payload     TEXT,
+    status      enum ('CREATED','FAILED','PUBLISHED'),
+    primary key (id)
+) engine=InnoDB;
+
 alter table if exists notification_log
     add constraint UKnotificationid unique (id);
 

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -101,12 +101,13 @@ create table notification_log
 
 create table outbox_event
 (
-    retry_count integer not null,
-    created_at  datetime(6),
-    id          bigint  not null auto_increment,
-    event_type  varchar(255),
-    payload     TEXT,
-    status      enum ('CREATED','FAILED','PUBLISHED'),
+    retry_count  integer not null,
+    created_at   datetime(6),
+    id           bigint  not null auto_increment,
+    aggregate_id bigint  not null,
+    event_type   varchar(255),
+    payload      TEXT,
+    status       enum ('CREATED','FAILED','PUBLISHED'),
     primary key (id)
 ) engine=InnoDB;
 


### PR DESCRIPTION
### 변경 내역
- 애플리케이션 이벤트를 카프카 메시징 발행으로 변경 [2cc7aae535405aabbed1632949107fd579fad5c4], [refactor: 1c5eb90b4ae7752ade5e10e0910ff999025dc70e]
- Transactional Outbox Pattern 적용 [67f43a4f437959785fffce1cca58e056d0a829c2, 1279dda54496aff032cb040bf07d74fd1b97aabc]
- 카프카 발행 실패 케이스 재처리 로직 구현 [b84efd9edb6468ea1645818f2c306e92dbeed2be]
- 예약 결제에 대한 내용은 현재 PR에 추가를 못하여서 아래 `18-1` (27 PR)에서 구현 및 적용 했습니다. 
   > #27 

**좌석 예약 기능 통합 테스트 결과**
![image](https://github.com/user-attachments/assets/d439f8f9-4a02-4a49-a8a2-c3c92a14af00)
![image](https://github.com/user-attachments/assets/aa5e4a42-4f1a-45b8-a415-317ae0f6d6b6)
![image](https://github.com/user-attachments/assets/f86a5b03-b87a-4470-9d15-8ed5d7b01927)

<br>

### 리뷰 포인트
- 제 패키지 구조는 아래와 같이 퍼사드 패턴을 적용해서 application 계층에 UseCase를 위한 클래스를 만들었습니다.
최대한 interface > application > domain > infra의 형태로 바라보게 했지만 이번에 추가한 Outbox는 적용하기 애매한 부분이 있습니다. application에서 EventPublisher에 의해 event가 발행되면 interfaces/event 의 Listener에서 Outbox Transaction을 처리하고 Kafka에 메시지를 보내는데, Outbox의 경우 해당하는 UseCase 없이 domain 기능을 제공한다고 생각됩니다. 때문에 application 을 건너뛰고 interfaces/event에서 domain의 OutboxEventStore을 호출(의존)해서 기능을 처리하게 했는데
이런식으로 계층을 건너 뛰어도 상관 없을까요??? [67f43a4f437959785fffce1cca58e056d0a829c2]
(단순 예 application에서 바로 repository 혹은 infra 계층 호출)

```
io.hhplus.conbool
├─ application
│    ├─ concert
│    │     ├─ ConcertBookingFacade
...
│    ├─ event
│    │     ├─ ConcertBookingEventPublisher
...
├─ domain
│    ├─ outbox
│    │     ├─ OutboxEventStore
...
├─ infra
│    ├─ db
...
│    ├─ kafka.producer
...
├─ interfaces
│    ├─ api
│    ├─ consumer
│    ├─ event
│    │     └─ ConcertBookingEventListener
 ... 
```
- 웹 상의 예제처럼 application.yml 에 토픽을 표기해서 관리했는데, 하드코딩을 해야하는 불편함 때문에 클래스의 String 변수로 관리포인트를 변경했습니다. 일반적으로 토픽은 어디에서 관리하나요? [5410b6296783c85377e98d82982498ff85e75a9b]
- @TransactionalEventHandler에서 카프카 처리 로직을 try ~ catch 블록으로 감싸서 메시징 처리의 성공 유무를 outbox 테이블에 업데이트하도록 했는데, 해당 로직의 관심사가 이 위치가 맞을까요?? 아니면 KafkaConcertBookingProducer.send(String msg) 메서드 내부에 들어가야할까요?? 옳은 책임 처리인지 잘 모르겠습니다. [67f43a4f437959785fffce1cca58e056d0a829c2]
- 처음 도메인과 유즈케이스를 설계할 때 예약은 ConcertBooking 결제는 BookingPayment 로 정의하고 각각 concert, booking 도메인 패키지에 넣었습니다. 설계한 저도 가끔 헷갈리게 되면 잘못된 설계일까요...???